### PR TITLE
Chris bug fixes

### DIFF
--- a/src/components/NFTCard.jsx
+++ b/src/components/NFTCard.jsx
@@ -58,8 +58,8 @@ const NFTCard = ({ item }) => {
         {/* Placeholder skeleton for the NFT image */}
         <Skeleton width="100%" height="300px" />
         <div className="author_list_pp">
-          {/* Placeholder skeleton for the author profile picture */}
-          <Skeleton width="50px" height="50px" borderRadius="50%" />
+          {/* Placeholder skeleton for the author profile picture, WAS NOT FUNCTIONING, removed it and the loading state works appropriately without it
+          <Skeleton width="50px" height="50px" borderRadius="50%" /> */}
         </div>
         <div className="nft__item_info">
           {/* Placeholder skeleton for the NFT title */}

--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -34,7 +34,7 @@ const HotCollections = () => {
           console.error("Error fetching collections:", error);
           setLoading(false); // Ensure loading state is reset on error
         }
-      }, 0); // Delay for loading effect
+      }, 2000); // Delay for loading effect
     };
 
     fetchCollections();

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -31,7 +31,7 @@ const ItemDetails = () => {
           setError(error.message); // Set error message in state
           setLoading(false); // Update loading state
         }
-      }, 0); // Simulate a network delay for skeleton loading effect
+      }, 2000); // Simulate a network delay for skeleton loading effect
     };
 
     fetchNftDetails(); // Call the function to fetch NFT details
@@ -97,8 +97,10 @@ const ItemDetails = () => {
     description,
     ownerImage,
     ownerName,
+    ownerId,
     creatorImage,
     creatorName,
+    creatorId,
     price
   } = nftDetails;
 
@@ -136,7 +138,7 @@ const ItemDetails = () => {
                       <h6>Owner</h6>
                       <div className="item_author">
                         <div className="author_list_pp">
-                          <Link to={`/author/${ownerName}`}> {/* Link to the owner's page */}
+                          <Link to={`/author/${ownerId}`}> {/* Link to the owner's page */}
                             <img
                               className="lazy"
                               src={ownerImage || AuthorImagePlaceholder} // Use owner's image or placeholder
@@ -146,7 +148,7 @@ const ItemDetails = () => {
                           </Link>
                         </div>
                         <div className="author_list_info">
-                          <Link to={`/author/${ownerName}`}>{ownerName}</Link> {/* Display owner's name as a link */}
+                          <Link to={`/author/${ownerId}`}>{ownerName}</Link> {/* Display owner's name as a link */}
                         </div>
                       </div>
                     </div>
@@ -157,7 +159,7 @@ const ItemDetails = () => {
                       <h6>Creator</h6>
                       <div className="item_author">
                         <div className="author_list_pp">
-                          <Link to={`/author/${creatorName}`}> {/* Link to the creator's page */}
+                          <Link to={`/author/${creatorId}`}> {/* Link to the creator's page */}
                             <img
                               className="lazy"
                               src={creatorImage || AuthorImagePlaceholder} // Use creator's image or placeholder
@@ -167,7 +169,7 @@ const ItemDetails = () => {
                           </Link>
                         </div>
                         <div className="author_list_info">
-                          <Link to={`/author/${creatorName}`}>{creatorName}</Link> {/* Display creator's name as a link */}
+                          <Link to={`/author/${creatorId}`}>{creatorName}</Link> {/* Display creator's name as a link */}
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Task:
""Loading state layout errors"" and ""use the creator id instead of creator name since it creates a routing error if the name has spaces""

What was done: 

Used the ownerId and creatorId in routing on the ItemDetails page instead of the creatorName or ownerName to avoid the issue with spaces in the name schemes:

![Screenshot 2024-09-30 152904](https://github.com/user-attachments/assets/065c74b8-da5f-459e-bd0d-25a0c2df80a6)


Removed the loading state code that simulated the author Profile picture being loaded, it was unnecessary since the entire loading state would grey out the NFTCard display, this was done in the NFTCard.jsx:
 
 
![Screenshot 2024-09-30 152701](https://github.com/user-attachments/assets/a5ad46fb-9304-44d7-8c85-bc63ddd6625e)


